### PR TITLE
fix: 회원가입 시 부여되는 ID의 초기화 값을 1로 변경

### DIFF
--- a/src/user/model/UserDAO.java
+++ b/src/user/model/UserDAO.java
@@ -4,7 +4,7 @@ import java.util.HashMap;
 
 public class UserDAO {
     private HashMap<Integer, User> userDb = new HashMap<>();
-    private int autoIncrementIndex = 0;
+    private int autoIncrementIndex = 1;
 
     public void insert(User user) {
         user.setId(autoIncrementIndex); // ID 설정


### PR DESCRIPTION
fix: 회원가입 시 부여되는 ID의 초기화 값을 1로 변경